### PR TITLE
Remove unused ps_misn

### DIFF
--- a/dat/missions/pirate/pir_cargo.lua
+++ b/dat/missions/pirate/pir_cargo.lua
@@ -191,12 +191,6 @@ function land()
       tk.msg("", fmt.f(cargo_land[rnd.rnd(1, #cargo_land)],
                {cargotype=_(cargo[1])}))
       player.pay(reward)
-      n = var.peek("ps_misn")
-      if n ~= nil then
-         var.push("ps_misn", n+1)
-      else
-         var.push("ps_misn", 1)
-      end
 
       -- increase faction
       if player.misnActive("Fake ID") then


### PR DESCRIPTION
#### Summary of Changes

This appears to be leftover code from a203865f9b5baf1f1529b11c0fbe233a7e3f86b8

#### Tests performed
1)
```sh
$ fgrep -r ps_misn
dat/missions/pirate/pir_cargo.lua:      n = var.peek("ps_misn")
dat/missions/pirate/pir_cargo.lua:         var.push("ps_misn", n+1)
dat/missions/pirate/pir_cargo.lua:         var.push("ps_misn", 1)
```
2) The mission still works

#### Tests needed

None
