### PR TITLE
Fix exception in "A Friend's Aid"

### DIFF
--- a/dat/missions/soromid/comingout/srm_comingout3.lua
+++ b/dat/missions/soromid/comingout/srm_comingout3.lua
@@ -178,7 +178,7 @@ function spawnChelseaShip(param)
    chelsea:setHilight()
    chelsea:setVisible()
    chelsea:setInvincPlayer()
-   chelsea:setNoBoard()
+   chelsea:setNoboard()
 
    hook.pilot(chelsea, "death", "chelsea_death")
    hook.pilot(chelsea, "jump", "chelsea_jump")

--- a/dat/missions/soromid/comingout/srm_comingout4.lua
+++ b/dat/missions/soromid/comingout/srm_comingout4.lua
@@ -197,7 +197,7 @@ function spawnChelseaShip(param)
    chelsea:setHilight()
    chelsea:setVisible()
    chelsea:setInvincPlayer()
-   chelsea:setNoBoard()
+   chelsea:setNoboard()
 
    hook.pilot(chelsea, "death", "chelsea_death")
    hook.pilot(chelsea, "jump", "chelsea_jump")


### PR DESCRIPTION
#### Summary of Changes

setNoBoard had incorrect capitalization. This caused an exception leading to incomplete initialization and soft-locking the mission 66% of the time.

#### Tests performed

I successfully completed the mission

#### Tests needed

None